### PR TITLE
Fix API Auth: Pass Auth Header Even Under Apache2

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -21,3 +21,5 @@ AddHandler fcgid-script .fcgi
 #
 RewriteCond %{REQUEST_FILENAME} !=/home1/culturp7/public_html/api-dev/v1/api.fcgi
 RewriteRule ^(.*)$ api.fcgi/$1 [QSA,L]
+# Pass the Authorization header, which Apache2 does not by default
+SetEnvIf Authorization "(.+)" HTTP_AUTHORIZATION=$1


### PR DESCRIPTION
Apache2 stopped passing the `HTTP_AUTHENTICATION` header between
processes (e.g. to CGI scripts like Flask), which prevented Flask from
getting authentication headers.
[source](https://linux.m2osw.com/http-authentication-header-missing-not-sent-my-cgi-script-why)

To fix this, this commit forces Apache2 to continue passing the
authentication header.